### PR TITLE
Hack in greyscale support

### DIFF
--- a/cluttool/cluttool.py
+++ b/cluttool/cluttool.py
@@ -279,7 +279,12 @@ class ColorLUT(object):
         if meta['alpha']:
             raise ValueError('Then given PNG file contains an alpha channel. Refusing.')
         if meta['greyscale']:
-            raise ValueError('Then given PNG file is greyscale. Refusing.')
+            def triple_generator(d):
+                for val in d:
+                    yield val
+                    yield val
+                    yield val
+            data = array(data.typecode, triple_generator(data))
         if meta['bitdepth'] not in (8, 16):
             raise ValueError('Then given PNG file specifies an unsupported bit depth. Refusing.')
         width_is_square_root_of_perfect_six_root = is_perfect_six_root(width**2)


### PR DESCRIPTION
This PR adds greyscale support. It's somewhat of a hack, since I didn't really dive into the code to understand how the math actually works, but it works.

Here's an example greyscale LUT:

![Kodak TRI-X 400 1 -](https://user-images.githubusercontent.com/102904/213335256-41cd7a3c-e78f-4706-8e7c-f2106b13867a.png)

And the output `.cube` for that LUT from `cluttool` is here: https://dropbox.dzombak.com/tmp/tri-x.cube